### PR TITLE
Prevent `result.stdout` and `result.stderr` error

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,8 +53,8 @@ class ServerlessPlugin {
           cwd: path.join(servicePath, '.serverless'),
         };
         const result = spawnSync(path.join(__dirname, '..', '.bin/babel'), args, options);
-        const stdout = result.stdout.toString();
-        const sterr = result.stderr.toString();
+        const stdout = result.stdout ? result.stdout.toString() : null;
+        const sterr = result.stderr ? result.stderr.toString() : null;
         if (stdout) {
           this.serverless.cli.log(`Babel compilation:\n${stdout}`);
         }


### PR DESCRIPTION
I had to change the code locally because it was failing due to result.stdout being undefined.

I am unaware of the underlying source of the issue, but these changes fixed it.
